### PR TITLE
Treat empty last-seen parameter the same as if the variable were not received.

### DIFF
--- a/ztreamy/server.py
+++ b/ztreamy/server.py
@@ -587,7 +587,7 @@ class _EventDispatcher(object):
                 self.streaming_clients.append(client)
             logging.info('Streaming client registered; stream: %i; comp: %i'\
                              %(client.streaming, client.compress))
-        if last_event_seen != None:
+        if last_event_seen:
             # Send the available events after the last seen event
             evs, none_lost = self.recent_events.newer_than(last_event_seen)
             if len(evs) > 0:


### PR DESCRIPTION
I believe this PR fixes #5, but I'm not quite sure about how I can fully test this scenario.

@jfisteus could you check this PR and if it doesn't fix the issue provide extra information about how-to reproduce this issue?