### PR TITLE
Use the SPARQL code which is part of rdflib core, instead of using the deprecated rdfextras.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 setuptools
 tornado
-rdflib
-rdfextras
+rdflib>=4.0
 rdflib-jsonld
 tweepy==2.3.0
 pycurl

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ if sys.version_info[0] != 2 or sys.version_info[1] not in [7]:
 # Dependencies
 requirements = ['setuptools',
                 'tornado',
-                'rdflib',
-                'rdfextras',
+                'rdflib>=4.0',
                 'rdflib-jsonld',
                 'tweepy==2.3.0',
                 'pycurl',

--- a/ztreamy/filters.py
+++ b/ztreamy/filters.py
@@ -37,7 +37,7 @@ and override its 'filter_event()' method.
 
 """
 import rdflib
-import rdfextras.sparql.parser
+from rdflib.plugins.sparql.parser import parseQuery
 from pyparsing import Word, Literal, NotAny, QuotedString, Group, Forward, \
                       Keyword, ZeroOrMore, printables, alphanums
 
@@ -204,7 +204,7 @@ class SPARQLFilter(Filter):
             raise ZtreamyException('Only ASK queries are allowed '
                                    'in SPARQLFilter')
         super(SPARQLFilter, self).__init__(callback)
-        self.query = rdfextras.sparql.parser.parse(sparql_query)
+        self.query = parseQuery(sparql_query)
 
     def filter_event(self, event):
         if self.callback is not None and isinstance(event, RDFEvent):


### PR DESCRIPTION
Resolves https://github.com/jfisteus/ztreamy/issues/14

I tested it using the filtering examples which are available in the [programming guide](https://github.com/jfisteus/ztreamy/blob/development/doc/programming.rst), but I'm not confident that this won't  possibly break something. 

@jfisteus care to review?