### PR TITLE
Support for Python 2.6 was dropped. Remove the 2.6 specific requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,6 @@ requirements = ['setuptools',
                 'httplib2',
                 'simplejson',
                 ]
-if sys.version_info[1] == 6:
-    requirements.append('argparse')
-
 
 setup(
     name = "ztreamy",


### PR DESCRIPTION
Support for Python 2.6 was dropped in release 0.3: 

https://github.com/jfisteus/ztreamy/blob/ztreamy-0.3/Changelog#L19

/cc @jfisteus 