### PR TITLE
Include the 'license' metadata in the setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     version = "0.3",
     author = "Jesus Arias Fisteus",
     description = ("A framework for publishing semantic events on the Web"),
+    license = 'GPL3',
     keywords = "rdf sensors web semantic-sensor-web",
     url = "http://www.it.uc3m.es/jaf/ztreamy",
     packages=['ztreamy', 'ztreamy.utils', 'ztreamy.tools',


### PR DESCRIPTION
We're missing `author_email` and `license` in the `setup.py` file:

    warning: check: missing meta-data: if 'author' supplied, 'author_email' must be supplied too

https://docs.python.org/2/distutils/setupscript.html#additional-meta-data

@jfisteus the `author_email` field is up to you, I don't know which email you want to use :smile: 

Related to #15 